### PR TITLE
Changing internal_temp to temp and temp to ext_temperature to matchags used at grafana.v2.sondehub.org

### DIFF
--- a/Sondehub.pas
+++ b/Sondehub.pas
@@ -145,8 +145,8 @@ begin
                 '"lon": ' + MyFormatFloat('0.00000', Longitude) + ',' +
                 '"alt": ' + MyFormatFloat('0', Altitude) + ',' +
                 DoubleToString('frequency', CurrentFrequency + FrequencyError / 1000.0, CurrentFrequency > 0.0) +
-                DoubleToString('internal_temp', InternalTemperature, HaveInternalTemperature) +
-                DoubleToString('temp', ExternalTemperature, HaveExternalTemperature) +
+                DoubleToString('temp', InternalTemperature, HaveInternalTemperature) +
+                DoubleToString('ext_temperature', ExternalTemperature, HaveExternalTemperature) +
                 DoubleToString('humidity', Humidity, HaveHumidity) +
                 DoubleToString('vel_h', Speed, HaveSpeed) +
                 DoubleToString('vel_v', AscentRate, HaveAscentRate) +


### PR DESCRIPTION
Changing internal_temp to temp and temp to ext_temperature in order to match up with the tags used at https://grafana.v2.sondehub.org/ and fixing https://github.com/daveake/HABBase/issues/10